### PR TITLE
Fix IOException thrown by sun.awt.X11.XDesktopPeer.launch

### DIFF
--- a/QuickOpener/src/com/sessonad/quickopener/commands/LinuxGnomeCommands.java
+++ b/QuickOpener/src/com/sessonad/quickopener/commands/LinuxGnomeCommands.java
@@ -1,29 +1,15 @@
 package com.sessonad.quickopener.commands;
 
 import com.sessonad.quickopener.OperatingSystem;
-import java.awt.Desktop;
-import java.io.File;
 
 /**
  *
  * @author SessonaD
  */
-public class LinuxGnomeCommands extends Commands{
+public class LinuxGnomeCommands extends Commands {
 
     @Override
-    public void browseInFileSystem(File current) throws Exception {
-        if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)){
-            Desktop.getDesktop().open(current);
-        }else{
-            String fullCommand=OperatingSystem.LINUX_GNOME.getFileSystemBrowserCommand() + current.getAbsolutePath();
-            Runtime.getRuntime().exec(fullCommand);
-        }        
+    public OperatingSystem getOperatingSystem() {
+        return OperatingSystem.LINUX_GNOME;
     }
-
-    @Override
-    public void openInShell(String currentPath) throws Exception {
-        String fullCommand = OperatingSystem.LINUX_GNOME.getShellCommand() + currentPath;
-        Runtime.getRuntime().exec(fullCommand);
-    } 
-    
 }

--- a/QuickOpener/src/com/sessonad/quickopener/commands/LinuxKdeCommands.java
+++ b/QuickOpener/src/com/sessonad/quickopener/commands/LinuxKdeCommands.java
@@ -1,29 +1,15 @@
 package com.sessonad.quickopener.commands;
 
 import com.sessonad.quickopener.OperatingSystem;
-import java.awt.Desktop;
-import java.io.File;
 
 /**
  *
  * @author SessonaD
  */
-public class LinuxKdeCommands extends Commands{
+public class LinuxKdeCommands extends Commands {
 
     @Override
-    public void browseInFileSystem(File current) throws Exception {
-        if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)){
-            Desktop.getDesktop().open(current);
-        }else{
-            String fullCommand=OperatingSystem.LINUX_KDE.getFileSystemBrowserCommand() + current.getAbsolutePath();
-            Runtime.getRuntime().exec(fullCommand);
-        }        
+    public OperatingSystem getOperatingSystem() {
+        return OperatingSystem.LINUX_KDE;
     }
-
-    @Override
-    public void openInShell(String currentPath) throws Exception {
-        String fullCommand = OperatingSystem.LINUX_KDE.getShellCommand() + currentPath;
-        Runtime.getRuntime().exec(fullCommand);
-    } 
-    
 }

--- a/QuickOpener/src/com/sessonad/quickopener/commands/LinuxLxdeCommands.java
+++ b/QuickOpener/src/com/sessonad/quickopener/commands/LinuxLxdeCommands.java
@@ -1,29 +1,15 @@
 package com.sessonad.quickopener.commands;
 
 import com.sessonad.quickopener.OperatingSystem;
-import java.awt.Desktop;
-import java.io.File;
 
 /**
  *
  * @author SessonaD
  */
-public class LinuxLxdeCommands extends Commands{
+public class LinuxLxdeCommands extends Commands {
 
     @Override
-    public void browseInFileSystem(File current) throws Exception {
-        if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)){
-            Desktop.getDesktop().open(current);
-        }else{
-            String fullCommand=OperatingSystem.LINUX_LXDE.getFileSystemBrowserCommand() + current.getAbsolutePath();
-            Runtime.getRuntime().exec(fullCommand);
-        }        
+    public OperatingSystem getOperatingSystem() {
+        return OperatingSystem.LINUX_LXDE;
     }
-
-    @Override
-    public void openInShell(String currentPath) throws Exception {
-        String fullCommand = OperatingSystem.LINUX_LXDE.getShellCommand() + currentPath;
-        Runtime.getRuntime().exec(fullCommand);
-    } 
-    
 }

--- a/QuickOpener/src/com/sessonad/quickopener/commands/LinuxUnknownCommands.java
+++ b/QuickOpener/src/com/sessonad/quickopener/commands/LinuxUnknownCommands.java
@@ -1,5 +1,6 @@
 package com.sessonad.quickopener.commands;
 
+import com.sessonad.quickopener.OperatingSystem;
 import java.awt.Desktop;
 import java.io.File;
 
@@ -7,20 +8,24 @@ import java.io.File;
  *
  * @author SessonaD
  */
-public class LinuxUnknownCommands extends Commands{
+public class LinuxUnknownCommands extends Commands {
 
     @Override
     public void browseInFileSystem(File current) throws Exception {
-        if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)){
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
             Desktop.getDesktop().open(current);
-        }else{
+        } else {
             throw new Exception("Not supported yet in this distro of Linux");
-        }        
+        }
     }
 
     @Override
     public void openInShell(String currentPath) throws Exception {
         throw new Exception("Not supported yet in this distro of Linux");
-    } 
-    
+    }
+
+    @Override
+    public OperatingSystem getOperatingSystem() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/QuickOpener/src/com/sessonad/quickopener/commands/LinuxXfceCommands.java
+++ b/QuickOpener/src/com/sessonad/quickopener/commands/LinuxXfceCommands.java
@@ -1,29 +1,15 @@
 package com.sessonad.quickopener.commands;
 
 import com.sessonad.quickopener.OperatingSystem;
-import java.awt.Desktop;
-import java.io.File;
 
 /**
  *
  * @author SessonaD
  */
-public class LinuxXfceCommands extends Commands{
+public class LinuxXfceCommands extends Commands {
 
     @Override
-    public void browseInFileSystem(File current) throws Exception {
-        if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)){
-            Desktop.getDesktop().open(current);
-        }else{
-            String fullCommand=OperatingSystem.LINUX_XFCE.getFileSystemBrowserCommand() + current.getAbsolutePath();
-            Runtime.getRuntime().exec(fullCommand);
-        }        
+    public OperatingSystem getOperatingSystem() {
+        return OperatingSystem.LINUX_XFCE;
     }
-
-    @Override
-    public void openInShell(String currentPath) throws Exception {
-        String fullCommand = OperatingSystem.LINUX_XFCE.getShellCommand() + currentPath;
-        Runtime.getRuntime().exec(fullCommand);
-    } 
-    
 }

--- a/QuickOpener/src/com/sessonad/quickopener/commands/MacOSCommands.java
+++ b/QuickOpener/src/com/sessonad/quickopener/commands/MacOSCommands.java
@@ -1,29 +1,15 @@
 package com.sessonad.quickopener.commands;
 
 import com.sessonad.quickopener.OperatingSystem;
-import java.awt.Desktop;
-import java.io.File;
 
 /**
  *
  * @author SessonaD
  */
-public class MacOSCommands extends Commands{
+public class MacOSCommands extends Commands {
 
     @Override
-    public void browseInFileSystem(File current) throws Exception {
-        if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)){
-            Desktop.getDesktop().open(current);
-        }else{
-            String fullCommand=OperatingSystem.MAC_OS.getFileSystemBrowserCommand() + current.getAbsolutePath();
-            Runtime.getRuntime().exec(fullCommand);
-        }        
+    public OperatingSystem getOperatingSystem() {
+        return OperatingSystem.MAC_OS;
     }
-
-    @Override
-    public void openInShell(String currentPath) throws Exception {
-        String fullCommand = OperatingSystem.MAC_OS.getShellCommand() + currentPath;
-        Runtime.getRuntime().exec(fullCommand);
-    } 
-    
 }

--- a/QuickOpener/src/com/sessonad/quickopener/commands/UnknownOSCommands.java
+++ b/QuickOpener/src/com/sessonad/quickopener/commands/UnknownOSCommands.java
@@ -1,5 +1,6 @@
 package com.sessonad.quickopener.commands;
 
+import com.sessonad.quickopener.OperatingSystem;
 import java.awt.Desktop;
 import java.io.File;
 
@@ -7,20 +8,24 @@ import java.io.File;
  *
  * @author SessonaD
  */
-public class UnknownOSCommands extends Commands{
+public class UnknownOSCommands extends Commands {
 
     @Override
     public void browseInFileSystem(File current) throws Exception {
-        if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)){
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
             Desktop.getDesktop().open(current);
-        }else{
+        } else {
             throw new Exception("Not supported yet in this Operating System");
-        }        
+        }
     }
 
     @Override
     public void openInShell(String currentPath) throws Exception {
         throw new Exception("Not supported yet in this Operating System");
-    } 
-    
+    }
+
+    @Override
+    public OperatingSystem getOperatingSystem() {
+        return OperatingSystem.UNKNOWN;
+    }
 }

--- a/QuickOpener/src/com/sessonad/quickopener/commands/WindowsCommands.java
+++ b/QuickOpener/src/com/sessonad/quickopener/commands/WindowsCommands.java
@@ -1,28 +1,15 @@
 package com.sessonad.quickopener.commands;
 
 import com.sessonad.quickopener.OperatingSystem;
-import java.awt.Desktop;
-import java.io.File;
 
 /**
  *
  * @author SessonaD
  */
-public class WindowsCommands extends Commands{
+public class WindowsCommands extends Commands {
 
     @Override
-    public void browseInFileSystem(File current) throws Exception {
-        if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)){
-            Desktop.getDesktop().open(current);
-        }else{
-            throw new UnsupportedOperationException("Desktop not supported in this version.");
-        }        
+    public OperatingSystem getOperatingSystem() {
+        return OperatingSystem.WINDOWS;
     }
-
-    @Override
-    public void openInShell(String currentPath) throws Exception {
-        String fullCommand=OperatingSystem.WINDOWS.getShellCommand() + currentPath;
-        Runtime.getRuntime().exec(fullCommand);
-    } 
-    
 }


### PR DESCRIPTION
Despite being on a Gnome3 system where Desktop.isSupported(Action.OPEN) claims to be supported, the following error is thrown:

java.io.IOException: Failed to show URI:file:/home/sebastien/dev/jruby-launcher/
    at sun.awt.X11.XDesktopPeer.launch(XDesktopPeer.java:114)
    at sun.awt.X11.XDesktopPeer.open(XDesktopPeer.java:77)
    at java.awt.Desktop.open(Desktop.java:272)
    at com.sessonad.quickopener.commands.LinuxGnomeCommands.browseInFileSystem(LinuxGnomeCommands.java:16)
    at com.sessonad.quickopener.actions.FileSystem.actionPerformed(FileSystem.java:40)
    at org.openide.awt.InjectorExactlyOne.actionPerformed(InjectorExactlyOne.java:78)
    at org.openide.awt.ContextAction$Performer.actionPerformed(ContextAction.java:226)

This pull request calls the process that is normally called when the Desktop.isSupported(Action.OPEN) call returns false as a fallback when the IOException is thrown.  It also includes a bit of refactoring to address the code repetition.
